### PR TITLE
ftplugin: Improve dist tag replacement

### DIFF
--- a/ftplugin/spec.vim
+++ b/ftplugin/spec.vim
@@ -2,7 +2,7 @@
 " Filename: spec.vim
 " Maintainer: Igor Gnatenko i.gnatenko.brain@gmail.com
 " Former Maintainer: Gustavo Niemeyer <niemeyer@conectiva.com> (until March 2014)
-" Last Change: Mon Jun 01 21:15 MSK 2015 Igor Gnatenko
+" Last Change: Wed Apr 20 16:20 EDT 2016 Todd Zullinger
 
 if exists("b:did_ftplugin")
 	finish
@@ -39,7 +39,11 @@ else:
         spec = rpm.spec(specfile)
         headers = spec.sourceHeader
         version = headers['Version']
-        release = ".".join(headers['Release'].split(".")[:-1])
+        release = headers['Release']
+        distmacro = '%dist'
+        dist = rpm.expandMacro(distmacro)
+        if dist and dist != distmacro:
+            release = release.replace(rpm.expandMacro('%dist'), '')
         vim.command("let ver = " + version)
         vim.command("let rel = " + release)
 PYEND


### PR DESCRIPTION
If a spec file has 'Release: 1' the GetRelVer() function failed because
it stripped the entire release string.  The intent appears to be
removing dist tags which are often appended (e.g.: 1.fc25).

This is less than ideal for 2 reasons: 1) Not all spec files use a dist
tag; and 2) Many spec files which use a dist tag append values after the
dist tag (e.g.: 1.fc25.1).  The first case causes a traceback when
calling the function:

```
Error detected while processing function <SNR>29_SpecChangelog..<SNR>29_GetRelVer:
line   22:
Traceback (most recent call last):
  File "<string>", line 19, in <module>
vim.error: Vim(let):E15: Invalid expression:
```

The latter case would silently strip the .1 from the release, leaving
the changelog version string as 1.fc25.  This case is also the
documented way to perform a release bump on an older Fedora branch:
https://fedoraproject.org/wiki/Packaging:NamingGuidelines#Minor_release_bumps_for_old_branches

Use the expanded %dist macro for replacing the dist tag to avoid such
problems.

Signed-off-by: Todd Zullinger tmz@pobox.com
